### PR TITLE
fix: stop automatically scrolling up

### DIFF
--- a/package/contents/ui/FullRepresentation.qml
+++ b/package/contents/ui/FullRepresentation.qml
@@ -163,7 +163,6 @@ Item {
     delegate: feedDelegate
     header: header
     footer: footer
-    snapMode: ListView.SnapToItem
   }
 
   Item {


### PR DESCRIPTION
Widget is automatically scrolling up when i lift LMB up. 
I don't think that this is intended so I fixed it